### PR TITLE
Integrate hodor and gitripper

### DIFF
--- a/app/api/[...path]/route.ts
+++ b/app/api/[...path]/route.ts
@@ -18,18 +18,12 @@ const INTERNAL_SERVICE_BASE_URLS: Record<string, () => string> = {
   archivist: getArchivistBaseUrl,
 }
 
-function getBaseUrlForInternalService(service: string): string | null {
-  const getter = INTERNAL_SERVICE_BASE_URLS[service]
-  if (!getter) return null
-  try {
-    return getter().replace(/\/+$/, '')
-  } catch {
-    return null
-  }
+function getBaseUrlForInternalService(): string | null {
+  return process.env['NEXT_PUBLIC_HODOR_URL']?.replace(/\/+$/, '') || null
 }
 
 async function proxyToBackend(req: NextRequest, path: string[]) {
-  const session = await auth.api.getSession({
+    const session = await auth.api.getSession({
     headers: {
       cookie: req.headers.get("cookie") || "",
     },
@@ -38,38 +32,8 @@ async function proxyToBackend(req: NextRequest, path: string[]) {
   if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-
-  const tokenData = await auth.api.getAccessToken({
-    body: {
-      providerId: "github",
-      userId: session.user.id,
-    },
-    headers: {
-      cookie: req.headers.get("cookie") || "",
-    },
-  })
-
-  if (!tokenData?.accessToken) {
-    return NextResponse.json({ error: "No GitHub access token" }, { status: 401 })
-  }
-
-  const [service, ...backendPathSegments] = path
-  if (!service || backendPathSegments.length === 0) {
-    return NextResponse.json(
-      { error: 'Path must be <service>/<backend-path> (e.g. dataforge/Dijkstra/v1/wp/username)' },
-      { status: 400 }
-    )
-  }
-
-  const baseUrl = getBaseUrlForInternalService(service)
-  if (!baseUrl) {
-    return NextResponse.json(
-      { error: `Unknown or unconfigured service: ${service}` },
-      { status: 400 }
-    )
-  }
-
-  const backendPath = backendPathSegments.join('/')
+  const baseUrl = getBaseUrlForInternalService()
+  const backendPath = path.join('/')
   const url = new URL(backendPath, baseUrl + '/')
   url.search = new URL(req.url).search
 
@@ -77,7 +41,7 @@ async function proxyToBackend(req: NextRequest, path: string[]) {
     method: req.method,
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${tokenData.accessToken}`,
+      'sessionId': session.session.id,
       'X-Internal-Secret': process.env.INTERNAL_API_SECRET!,
     },
     body: req.method !== 'GET' && req.method !== 'DELETE'

--- a/app/api/auth/github-auth-token/route.ts
+++ b/app/api/auth/github-auth-token/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { getAuthTokenForGithubAccountController } from "@/nextjs-server/Controllers/AuthDataController";
+
+export async function GET(request: NextRequest) {
+  return getAuthTokenForGithubAccountController(request);
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -7,7 +7,7 @@ import { StepNavigation } from "@/components/onboarding/step-navigation";
 import { useOnboardingForm } from "@/hooks/onboarding/use-onboarding-form";
 import { useOnboardingNavigation } from "@/hooks/onboarding/use-onboarding-navigation";
 import { authClient } from "@/lib/auth/auth-client";
-import { WelcomeStep } from "@/app/onboarding/Steps/step-welcome";
+import { WelcomeStep } from "@/app/onboarding/steps/step-welcome";
 import { OnboardingFlowBody } from "@/components/onboarding/onboarding-flow-body";
 import { useOAuthAccounts } from "@/hooks/onboarding/use-oauth-accounts";
 

--- a/components/section-cards.tsx
+++ b/components/section-cards.tsx
@@ -33,6 +33,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { API_URLS } from "@/lib/api/url-builders";
 import type { LeetCodeStatisticsResponse } from "@/types/client/dashboard/leetcode-statistics";
 import { getPersonalDetailsByGithubUsername } from "@/services/profile/PersonalDetailsService";
+import { useFetchLeetCodeData } from "@/hooks/leetcode/use-fetch-leetcode-data";
 
 const chartConfig2 = {
   easy: {
@@ -257,18 +258,7 @@ export function SectionCards() {
   }));
   const leetcodeUsername = personalDetails?.leetcodeUserName?.trim() ?? "";
 
-  const { data: statsResponse, isLoading: statsLoading, error: statsError } = useQuery({
-    queryKey: ["leetcode-statistics", leetcodeUsername],
-    queryFn: async (): Promise<LeetCodeStatisticsResponse> => {
-      const res = await fetch(API_URLS.getLeetcodeStatisticsUrl(leetcodeUsername));
-      if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
-      return res.json();
-    },
-    enabled: !!leetcodeUsername,
-    staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 30,
-  });
-
+  const { data: statsResponse, isLoading: statsLoading, error: statsError } = useFetchLeetCodeData(leetcodeUsername);
   const pieData = transformStatsToPieData(statsResponse);
   const { easy, medium, hard, total: totalProblems } = getLeetcodeTotals(statsResponse);
   const contestRanking = statsResponse?.leetcode?.contestRanking;

--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -5,3 +5,4 @@ export const TEAMNAMES = process.env.TEAM_NAMES;
 export const ORG = process.env.ORG;
 export const JOIN_PAGE = process.env.NEXT_PUBLIC_JOINING_PAGE_URL || "https://github.com/Dijkstra-Edu";
 export const DOMAIN = process.env.DOMAIN;
+export const GITHUB_OAUTH_URL = "https://github.com/login/oauth/access_token";

--- a/hooks/leetcode/use-fetch-leetcode-data.ts
+++ b/hooks/leetcode/use-fetch-leetcode-data.ts
@@ -1,0 +1,14 @@
+import { getLeetCodeStatistics } from "@/services/dashboard/LeetCodeDataFetchService";
+import { useQuery } from "@tanstack/react-query";
+
+export function useFetchLeetCodeData(
+  leetcodeUsername: string
+) {
+    return useQuery({
+        queryKey: ["leetcode-statistics", leetcodeUsername],
+        queryFn: () => getLeetCodeStatistics(leetcodeUsername),
+        enabled: !!leetcodeUsername,
+        staleTime: 1000 * 60 * 5,
+        gcTime: 1000 * 60 * 30,
+  });
+}

--- a/lib/api/url-builders.ts
+++ b/lib/api/url-builders.ts
@@ -11,9 +11,7 @@ export const API_URLS = {
     )}${allData ? "?all_data=true" : ""}`,
 
   getLeetcodeStatisticsUrl: (leetcodeUsername: string) =>
-    `${
-      API_ENDPOINTS.DATAFORGE_API
-    }/Dijkstra/v1/statistics/lc/${encodeURIComponent(leetcodeUsername)}`,
+    `/Dijkstra/v1/statistics/lc/${encodeURIComponent(leetcodeUsername)}`,
 
     //Dashboard - Profile Operations
     

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -67,21 +67,5 @@ export const auth = betterAuth({
       permissions: 2048 | 16384,
     },
   },
-  plugins: [nextCookies(),
-    customSession(async ({ user, session }) => {
-          const authToken: string = (await auth.api.getAccessToken({
-                  body: {
-                    providerId: "github",
-                  },
-                  headers: await headers() 
-          })).accessToken;
-          return {
-                user: {
-                    ...user,
-                    access_token: authToken,
-                },
-                session
-            };
-        }),
-  ],
+  plugins: [nextCookies()],
 });

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -1,6 +1,8 @@
 import { betterAuth } from "better-auth";
 import { nextCookies } from "better-auth/next-js";
 import { authPgPool } from "../db/postgres";
+import { customSession } from "better-auth/plugins";
+import { headers } from "next/headers";
 
 function requireEnv(key: string): string {
     const value = process.env[key];
@@ -65,5 +67,21 @@ export const auth = betterAuth({
       permissions: 2048 | 16384,
     },
   },
-  plugins: [nextCookies()],
+  plugins: [nextCookies(),
+    customSession(async ({ user, session }) => {
+          const authToken: string = (await auth.api.getAccessToken({
+                  body: {
+                    providerId: "github",
+                  },
+                  headers: await headers() 
+          })).accessToken;
+          return {
+                user: {
+                    ...user,
+                    access_token: authToken,
+                },
+                session
+            };
+        }),
+  ],
 });

--- a/lib/db/postgres.ts
+++ b/lib/db/postgres.ts
@@ -1,5 +1,4 @@
-import { Pool } from "@neondatabase/serverless";
-
+import { Pool } from "pg";
 const connectionString = process.env.DIJKSTRA_WEB_DB_URL;
 
 if (!connectionString) {

--- a/nextjs-server/Controllers/AuthDataController.ts
+++ b/nextjs-server/Controllers/AuthDataController.ts
@@ -10,7 +10,7 @@ export async function getAuthTokenForGithubAccountController(request: NextReques
       );
     }
     const authToken = await getAuthTokenForGithubAccount(accountId);
-    return NextResponse.json({ authToken }, { status: 200 });
+    return NextResponse.json(authToken, { status: 200 });
   } catch (error) {
     console.error("Error fetching GitHub auth token:", error);
     return NextResponse.json(

--- a/nextjs-server/Controllers/AuthDataController.ts
+++ b/nextjs-server/Controllers/AuthDataController.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthTokenForGithubAccount } from "@/nextjs-server/Services/AuthDataService";
+export async function getAuthTokenForGithubAccountController(request: NextRequest) {
+  try {
+    const accountId = request.nextUrl.searchParams.get("accountId");
+     if (!accountId) {
+      return NextResponse.json(
+        { message: "accountId is required" },
+        { status: 400 }
+      );
+    }
+    const authToken = await getAuthTokenForGithubAccount(accountId);
+    return NextResponse.json({ authToken }, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching GitHub auth token:", error);
+    return NextResponse.json(
+      {
+        message:
+          error instanceof Error
+            ? error.message
+            : "Unable to get auth token for GitHub account",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/nextjs-server/NextJsDBIntegration.ts
+++ b/nextjs-server/NextJsDBIntegration.ts
@@ -1,6 +1,6 @@
 import { authPgPool } from "@/lib/db/postgres";
 
-export type SqlParam = string | number | boolean | null;
+export type SqlParam = string | number | boolean | Date | null;
 
 export async function queryNextJsDb<T = unknown>(
   sql: string,

--- a/nextjs-server/Repository/AuthDataRepository.ts
+++ b/nextjs-server/Repository/AuthDataRepository.ts
@@ -1,0 +1,56 @@
+import { GithubAccountDto } from "@/types/server/next-js/auth/types";
+import { queryOneNextJsDb } from "../NextJsDBIntegration";
+
+export async function getGithubAccount(
+  accountId: string
+): Promise<GithubAccountDto | null> {
+  return queryOneNextJsDb<GithubAccountDto>(
+      `SELECT
+          "accountId",
+          "accessToken",
+          "refreshToken",
+          "accessTokenExpiresAt",
+          "refreshTokenExpiresAt"
+      FROM "account" 
+      WHERE "accountId" = $1
+      LIMIT 1`,
+      [accountId]
+    );
+}
+
+export async function updateRefreshedGithubAuthToken(
+  accountId: string,
+  accessToken: string,
+  accessTokenExpiresIn: number,
+  refreshToken: string,
+  refreshTokenExpiresIn: number
+): Promise<GithubAccountDto | null> {
+  const now = new Date();
+
+  const accessTokenExpiresAt = new Date(
+    now.getTime() + accessTokenExpiresIn * 1000
+  );
+
+  const refreshTokenExpiresAt = new Date(
+    now.getTime() + refreshTokenExpiresIn * 1000
+  );
+
+  return queryOneNextJsDb<GithubAccountDto>(
+    `UPDATE "account"
+     SET
+         "accessToken" = $2,
+         "accessTokenExpiresAt" = $3,
+         "refreshToken" = $4,
+         "refreshTokenExpiresAt" = $5
+     WHERE "accountId" = $1
+     RETURNING *`,
+    [
+      accountId,
+      accessToken,
+      accessTokenExpiresAt,
+      refreshToken,
+      refreshTokenExpiresAt,
+    ]
+  );
+}
+

--- a/nextjs-server/Services/AuthDataService.ts
+++ b/nextjs-server/Services/AuthDataService.ts
@@ -1,0 +1,44 @@
+import { getGithubAccount, updateRefreshedGithubAuthToken } from "../Repository/AuthDataRepository";
+import { GITHUB_OAUTH_URL } from "@/constants/constants";
+
+//TODO: Implement locking to prevent race conditions
+export async function getAuthTokenForGithubAccount(
+  accountId: string
+): Promise<string | null> {
+  console.log("Fetching GitHub auth token for accoun", accountId);
+  const githubAccount = await getGithubAccount(accountId);
+  if (!githubAccount?.refreshTokenExpiresAt ||
+    githubAccount.refreshTokenExpiresAt < new Date()) {
+    // If the refresh token is expired, return error
+    throw new Error("Refresh token expired");
+  }
+  if (!githubAccount?.accessTokenExpiresAt || githubAccount.accessTokenExpiresAt < new Date()) {
+      console.log("Refresh token:", githubAccount.refreshToken);
+      const res = await fetch(GITHUB_OAUTH_URL, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          },
+          body: JSON.stringify({
+            client_id: process.env.GITHUB_APP_CLIENT_ID,
+            client_secret: process.env.GITHUB_APP_CLIENT_SECRET,
+            grant_type: "refresh_token",
+            refresh_token: githubAccount.refreshToken,
+          }),
+      });
+      const data = await res.json();
+      console.log("Response from GitHub OAuth token refresh:", data);
+      console.log("Response status:", res.status);
+      if (res.ok && !data.error) {
+        // If the request was successful, return the new access token
+        await updateRefreshedGithubAuthToken(accountId, data.access_token, data.expires_in, data.refresh_token, data.refresh_token_expires_in);
+        return data.access_token;
+      } else {
+          // If the request failed, throw an error
+          throw new Error("Unable to refresh access token");
+        }
+  }
+    return githubAccount ? githubAccount.accessToken : null;
+}
+   

--- a/nextjs-server/Services/AuthDataService.ts
+++ b/nextjs-server/Services/AuthDataService.ts
@@ -1,11 +1,12 @@
+import { GithubAccessTokenDto } from "@/types/server/next-js/auth/types";
 import { getGithubAccount, updateRefreshedGithubAuthToken } from "../Repository/AuthDataRepository";
 import { GITHUB_OAUTH_URL } from "@/constants/constants";
 
 //TODO: Implement locking to prevent race conditions
 export async function getAuthTokenForGithubAccount(
   accountId: string
-): Promise<string | null> {
-  console.log("Fetching GitHub auth token for accoun", accountId);
+): Promise<GithubAccessTokenDto | null> {
+  console.log("Fetching GitHub auth token for account", accountId);
   const githubAccount = await getGithubAccount(accountId);
   if (!githubAccount?.refreshTokenExpiresAt ||
     githubAccount.refreshTokenExpiresAt < new Date()) {
@@ -32,13 +33,16 @@ export async function getAuthTokenForGithubAccount(
       console.log("Response status:", res.status);
       if (res.ok && !data.error) {
         // If the request was successful, return the new access token
-        await updateRefreshedGithubAuthToken(accountId, data.access_token, data.expires_in, data.refresh_token, data.refresh_token_expires_in);
-        return data.access_token;
+        const updatedGithubAccount = await updateRefreshedGithubAuthToken(accountId, data.access_token, data.expires_in, data.refresh_token, data.refresh_token_expires_in);
+        if(updatedGithubAccount == null) {
+          throw new Error("Unable to refresh access token");
+        }
+        return { accessToken: updatedGithubAccount.accessToken, expiresAt: updatedGithubAccount.accessTokenExpiresAt } as GithubAccessTokenDto;
       } else {
           // If the request failed, throw an error
           throw new Error("Unable to refresh access token");
         }
   }
-    return githubAccount ? githubAccount.accessToken : null;
+    return githubAccount ?  { accessToken: githubAccount.accessToken, expiresAt: githubAccount.accessTokenExpiresAt } as GithubAccessTokenDto : null;
 }
    

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "next": "15.5.9",
     "next-remove-imports": "^1.0.12",
     "next-themes": "^0.4.6",
+    "pg": "^8.20.0",
     "react": "^19.0.0",
     "react-calendar-heatmap": "^1.10.0",
     "react-day-picker": "^9.9.0",

--- a/services/dashboard/LeetCodeDataFetchService.ts
+++ b/services/dashboard/LeetCodeDataFetchService.ts
@@ -1,0 +1,12 @@
+
+import { API_URLS } from "@/lib/api/url-builders";
+import { apiCall } from "@/services/CoreApiService";
+import { LeetCodeStatisticsResponse } from "@/types/client/dashboard/leetcode-statistics";
+
+export async function getLeetCodeStatistics(
+  leetcodeUsername: string
+): Promise<LeetCodeStatisticsResponse> {
+    const raw = await apiCall<LeetCodeStatisticsResponse>("dataforge", API_URLS.getLeetcodeStatisticsUrl(leetcodeUsername));
+    return raw;
+}
+

--- a/types/server/next-js/auth/types.ts
+++ b/types/server/next-js/auth/types.ts
@@ -5,3 +5,8 @@ export type GithubAccountDto = {
   accessTokenExpiresAt: Date
   refreshTokenExpiresAt: Date
 }
+
+export type GithubAccessTokenDto = {
+  accessToken: string
+  expiresAt: Date
+}

--- a/types/server/next-js/auth/types.ts
+++ b/types/server/next-js/auth/types.ts
@@ -1,0 +1,7 @@
+export type GithubAccountDto = {
+  accountId: string
+  accessToken: string
+  refreshToken: string
+  accessTokenExpiresAt: Date
+  refreshTokenExpiresAt: Date
+}


### PR DESCRIPTION
The following changes were made in this PR:
1. Gitripper integration: Gitripper will no longer receive the accessToken but will instead fetch it as needed from dijkstra-web. Therefore, this PR adds an API that will return the accessToken for a given github acount id. The API handles the access token refresh logic on expiration as well.
2. Hodor integration. All calls to backend services will now be made through hodor. This requires a simple change in the core NextJS proxy handler.
3. Refactor the leetcode data fetch logic to better follow existing code patterns